### PR TITLE
Fix travis deploying build pushed PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ after_success:
   - vendor/bin/coveralls -v
   - vendor/bin/phpcs -n --standard=PSR1,PSR2 src/
   - vendor/bin/phpcbf src/
-  - ENVIRONMENT_NAME=$TRAVIS_BRANCH
+  - ENVIRONMENT_NAME=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - if [ "$TRAVIS_BRANCH" == "master" ]; then ENVIRONMENT_NAME=production; fi
 deploy:
   - provider: script


### PR DESCRIPTION
Proposed fix to bug where our typical .travis.yml attempts to build and
deploy an app when processing a ["build pushed
PR"](https://docs.travis-ci.com/user/web-ui/#build-pushed-pull-requests).

When we create a PR for "my-feature" targetting "development", if "Build
pushed pull requests" is enabled for the repo (default true?) Travis
will helpfully checkout the target branch ("development"), merge the PR
branch ("my-feature"), and if tests pass, will attempt to deploy to
"development" because $TRAVIS_BRANCH is "development". In effect,
*proposing* changes to "development" actually *deploy* those changes to
"development".

This fix works around that by examining $TRAVIS_PULL_REQUEST_BRANCH
first. If that var is set to anything, we'll use that as
$ENVIRONMENT_NAME. In the scenario above, $ENVIRONMENT_NAME will be
"my-feature", preventing a deploy. For *actual* updates to
"development", $TRAVIS_PULL_REQUEST_BRANCH will be unset, initializing
$ENVIRONMENT_NAME to the value of $TRAVIS_BRANCH as before
("development").